### PR TITLE
make a single version attribute for future packaging simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For packaging on PyPI:
 
 `python -m build; twine upload dist/*`
 
-Be sure to bump the version in both the docs/conf.py and in setup.py
+Be sure to bump the version in `__init__.py`.
 
 ## License
 This code is made available under the terms of the _MIT Open License_:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,13 +17,13 @@
 
 # -- Project information -----------------------------------------------------
 
+import molSim
 project = 'molSim'
 copyright = '2022, Jackson Burns, Himaghna Bhattacharjee'
 author = 'Jackson Burns, Himaghna Bhattacharjee'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.5'
-
+release = molSim.__version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/molSim/__init__.py
+++ b/molSim/__init__.py
@@ -2,3 +2,5 @@ from . import ops
 from . import tasks
 from . import chemical_datastructures
 from . import utils
+
+__version__ = "0.0.6"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import molSim
 import pathlib
 from setuptools import setup, find_packages
 
@@ -7,9 +8,11 @@ README = (cwd / "README.md").read_text()
 
 desc = "Python command line and GUI tool to analyze molecular similarity."
 
+vers = molSim.__version__
+
 setup(
     name="molSim",
-    version="0.0.5",
+    version=vers,
     description=desc,
     long_description=README,
     long_description_content_type="text/markdown",

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+import molSim
+
+print(molSim.__version__)


### PR DESCRIPTION
currently, the documentation configuration file and the pypi setup file have a version attirbute, and both have to be updated for any updates to molSim. This PR should allow all necessary components of molSim to pull the version from one attirbute.

May also try adding an automated version bumper